### PR TITLE
fix: correct Pandoc archive paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,11 @@ jobs:
 
           # Darwin ARM64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-arm64-macOS.zip" -o /tmp/pandoc-darwin-arm64.zip
-          unzip -p /tmp/pandoc-darwin-arm64.zip "pandoc-${PANDOC_VER}/bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-arm64.gz"
+          unzip -p /tmp/pandoc-darwin-arm64.zip "bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-arm64.gz"
 
           # Darwin x64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-x86_64-macOS.zip" -o /tmp/pandoc-darwin-x64.zip
-          unzip -p /tmp/pandoc-darwin-x64.zip "pandoc-${PANDOC_VER}/bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-x64.gz"
+          unzip -p /tmp/pandoc-darwin-x64.zip "bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-x64.gz"
 
           # Linux x64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-linux-amd64.tar.gz" -o /tmp/pandoc-linux-x64.tar.gz
@@ -133,7 +133,7 @@ jobs:
 
           # Windows x64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-windows-x86_64.zip" -o /tmp/pandoc-win32-x64.zip
-          unzip -p /tmp/pandoc-win32-x64.zip "pandoc-${PANDOC_VER}/pandoc.exe" | gzip > "dist/binaries/pandoc-win32-x64.gz"
+          unzip -p /tmp/pandoc-win32-x64.zip "pandoc.exe" | gzip > "dist/binaries/pandoc-win32-x64.gz"
 
           echo "✅ Pandoc binaries downloaded"
 


### PR DESCRIPTION
Fixes the release workflow failing to extract Pandoc binaries.

## Problem
The workflow was trying to extract Pandoc binaries using incorrect paths:
- macOS zips were looking for `pandoc-3.6.4/bin/pandoc` but archives only contain `bin/pandoc`  
- Windows zips were looking for `pandoc-3.6.4/pandoc.exe` but archives only contain `pandoc.exe`

## Solution
Updated paths to match actual Pandoc release archive structure:
- **macOS**: `bin/pandoc` (no version prefix)
- **Windows**: `pandoc.exe` (no version prefix)
- **Linux**: `pandoc-3.6.4/bin/pandoc` (keeps version prefix in tar.gz)

This was discovered when the release workflow failed after PR #42 was merged.