### PR TITLE
chore: trigger 1.1.0 release

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,3 +9,4 @@
   "fundingUrl": "https://github.com/sponsors/benjamincassidy",
   "isDesktopOnly": false
 }
+  


### PR DESCRIPTION
Trigger the release workflow for version 1.1.0.

This PR makes a trivial change to manifest.json to trigger the automated release workflow. Once merged, the workflow will:

1. Download Pandoc and Typst binaries for all platforms
2. Generate tools-manifest.json
3. Create GitHub release 1.1.0 with all assets
4. Attach main.js, manifest.json, styles.css, and all binaries

The release will include all features from PR #42 (project compilation and export system).