### PR TITLE
chore: update to Pandoc 3.9.0.2 and Typst 0.14.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           set -euo pipefail
           mkdir -p dist/binaries
           VERSION="${{ steps.version_check.outputs.VERSION }}"
-          PANDOC_VER="3.6.4"
+          PANDOC_VER="3.9.0.2"
 
           echo "📦 Downloading Pandoc ${PANDOC_VER} for all platforms..."
           PANDOC_BASE="https://github.com/jgm/pandoc/releases/download/${PANDOC_VER}"
@@ -141,7 +141,7 @@ jobs:
         if: steps.version_check.outputs.should_release == 'true'
         run: |
           set -euo pipefail
-          TYPST_VER="0.12.0"
+          TYPST_VER="0.14.2"
 
           echo "📦 Downloading Typst ${TYPST_VER} for all platforms..."
           TYPST_BASE="https://github.com/typst/typst/releases/download/v${TYPST_VER}"


### PR DESCRIPTION
Updates binary versions in release workflow to latest stable releases.

## Changes
- **Pandoc**: 3.6.4 → 3.9.0.2 (latest stable)
- **Typst**: 0.12.0 → 0.14.2 (latest stable)

## Why
- The 3.6.4 Pandoc archives had inconsistent directory structures causing extraction failures
- Newer versions are more stable and include bug fixes
- Users will benefit from latest features and improvements

This should be merged before PR #44 to ensure the release workflow uses correct versions.