### PR TITLE
fix: correct Pandoc 3.9.0.2 archive paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,11 @@ jobs:
 
           # Darwin ARM64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-arm64-macOS.zip" -o /tmp/pandoc-darwin-arm64.zip
-          unzip -p /tmp/pandoc-darwin-arm64.zip "bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-arm64.gz"
+          unzip -p /tmp/pandoc-darwin-arm64.zip "pandoc-${PANDOC_VER}-arm64/bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-arm64.gz"
 
           # Darwin x64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-x86_64-macOS.zip" -o /tmp/pandoc-darwin-x64.zip
-          unzip -p /tmp/pandoc-darwin-x64.zip "bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-x64.gz"
+          unzip -p /tmp/pandoc-darwin-x64.zip "pandoc-${PANDOC_VER}-x86_64/bin/pandoc" | gzip > "dist/binaries/pandoc-darwin-x64.gz"
 
           # Linux x64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-linux-amd64.tar.gz" -o /tmp/pandoc-linux-x64.tar.gz
@@ -133,7 +133,7 @@ jobs:
 
           # Windows x64
           curl -fsSL "${PANDOC_BASE}/pandoc-${PANDOC_VER}-windows-x86_64.zip" -o /tmp/pandoc-win32-x64.zip
-          unzip -p /tmp/pandoc-win32-x64.zip "pandoc.exe" | gzip > "dist/binaries/pandoc-win32-x64.gz"
+          unzip -p /tmp/pandoc-win32-x64.zip "pandoc-${PANDOC_VER}/pandoc.exe" | gzip > "dist/binaries/pandoc-win32-x64.gz"
 
           echo "✅ Pandoc binaries downloaded"
 


### PR DESCRIPTION
Fixes archive extraction paths for Pandoc 3.9.0.2 binaries.

## Problem

The Pandoc 3.9.0.2 archives have different directory structures by platform:
- **macOS**: `pandoc-3.9.0.2-{arch}/bin/pandoc` (includes architecture in path)
- **Windows**: `pandoc-3.9.0.2/pandoc.exe` (version prefix only)
- **Linux**: `pandoc-3.9.0.2/bin/pandoc` (version prefix only, already correct)

## Solution

Updated `unzip -p` paths to match the actual archive structures for each platform.

## Testing

Manually verified archive contents:
```bash
# macOS ARM64
unzip -l pandoc-3.9.0.2-arm64-macOS.zip
# Shows: pandoc-3.9.0.2-arm64/bin/pandoc

# macOS x86_64
unzip -l pandoc-3.9.0.2-x86_64-macOS.zip
# Shows: pandoc-3.9.0.2-x86_64/bin/pandoc

# Windows
unzip -l pandoc-3.9.0.2-windows-x86_64.zip
# Shows: pandoc-3.9.0.2/pandoc.exe
```

Must be merged before PR #44 to ensure the release workflow succeeds.