### PR TITLE
chore: trigger 1.1.0 release

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,3 +10,4 @@
   "isDesktopOnly": false
 }
   
+


### PR DESCRIPTION
Triggers the 1.1.0 release workflow with all fixes in place.

## Context

All the necessary fixes are now merged:
- ✅ PR #42: Project compilation and export feature
- ✅ PR #43: Initial Pandoc archive path fixes
- ✅ PR #45: Updated to Pandoc 3.9.0.2 and Typst 0.14.2
- ✅ PR #46: Corrected Pandoc 3.9.0.2 archive paths

PR #44 was merged earlier but the workflow ran before PR #46 was merged, so it failed. This PR will trigger the workflow again with all fixes in place.

## Changes

Trivial whitespace change to `manifest.json` to trigger the release workflow.

## Release Contents

This will create release 1.1.0 with:
- Project compilation and export (PDF via Typst, DOCX/EPUB via Pandoc)
- CSL citation system with 10 bundled styles
- 3 manuscript export styles
- Binary distribution system for Pandoc and Typst
- All platform binaries (macOS arm64/x64, Linux arm64/x64, Windows x64)