### PR TITLE
fix: exclude markdown syntax from word counts

### DIFF
--- a/src/core/WordCounter.test.ts
+++ b/src/core/WordCounter.test.ts
@@ -45,6 +45,65 @@ describe('WordCounter', () => {
       expect(result.words).toBe(3)
     })
 
+    it('should not count heading markers as words', () => {
+      const result = counter.countText('# Heading One\n## Heading Two\n### Heading Three')
+
+      expect(result.words).toBe(6) // "Heading One Heading Two Heading Three"
+    })
+
+    it('should not count list markers as words', () => {
+      const result = counter.countText('- First item\n- Second item\n* Third item\n+ Fourth item')
+
+      expect(result.words).toBe(8) // "First item Second item Third item Fourth item"
+    })
+
+    it('should not count numbered list markers as words', () => {
+      const result = counter.countText('1. First item\n2. Second item\n10. Tenth item')
+
+      expect(result.words).toBe(6) // "First item Second item Tenth item"
+    })
+
+    it('should handle bold and italic markdown', () => {
+      const result = counter.countText('This is **bold** and *italic* text')
+
+      expect(result.words).toBe(6) // "This is bold and italic text"
+    })
+
+    it('should handle strikethrough markdown', () => {
+      const result = counter.countText('This is ~~crossed out~~ text')
+
+      expect(result.words).toBe(5) // "This is crossed out text"
+    })
+
+    it('should handle blockquotes', () => {
+      const result = counter.countText('> This is a quote\n> Second line')
+
+      expect(result.words).toBe(6) // "This is a quote Second line"
+    })
+
+    it('should not count horizontal rules', () => {
+      const result = counter.countText('Text before\n---\nText after')
+
+      expect(result.words).toBe(4) // "Text before Text after"
+    })
+
+    it('should handle complex markdown with multiple syntax elements', () => {
+      const text = `# Main Heading
+
+This is **bold** and *italic* text.
+
+- List item one
+- List item two
+
+> A quote here
+
+More text.`
+
+      const result = counter.countText(text)
+
+      expect(result.words).toBe(19) // All words without markdown syntax
+    })
+
     it('should exclude frontmatter by default', () => {
       const text = `---
 title: Test

--- a/src/core/WordCounter.ts
+++ b/src/core/WordCounter.ts
@@ -157,8 +157,38 @@ export class WordCounter {
     const characters = trimmedText.length
     const charactersNoSpaces = trimmedText.replace(/\s/g, '').length
 
+    // Strip markdown syntax before counting words
+    let cleanedText = trimmedText
+
+    // Remove horizontal rules (---, ***, ___)
+    cleanedText = cleanedText.replace(/^[-*_]{3,}\s*$/gm, '')
+
+    // Remove heading markers (# ## ### etc.)
+    cleanedText = cleanedText.replace(/^#{1,6}\s+/gm, '')
+
+    // Remove blockquote markers (>)
+    cleanedText = cleanedText.replace(/^>\s*/gm, '')
+
+    // Remove list markers (-, *, +, 1., 2., etc.)
+    cleanedText = cleanedText.replace(/^[\s]*[-*+]\s+/gm, '')
+    cleanedText = cleanedText.replace(/^[\s]*\d+\.\s+/gm, '')
+
+    // Remove bold/italic markers (**text**, __text__, *text*, _text_)
+    // First handle bold (** or __)
+    cleanedText = cleanedText.replace(/\*\*([^*]+)\*\*/g, '$1')
+    cleanedText = cleanedText.replace(/__([^_]+)__/g, '$1')
+    // Then handle italic (* or _)
+    cleanedText = cleanedText.replace(/\*([^*]+)\*/g, '$1')
+    cleanedText = cleanedText.replace(/_([^_]+)_/g, '$1')
+
+    // Remove strikethrough (~~text~~)
+    cleanedText = cleanedText.replace(/~~([^~]+)~~/g, '$1')
+
+    // Remove remaining standalone markdown characters that might be counted as words
+    cleanedText = cleanedText.replace(/^[#*\-_>]+$/gm, '')
+
     // Count words: split by whitespace, filter empty strings
-    const words = trimmedText.split(/\s+/).filter((word) => word.length > 0).length
+    const words = cleanedText.split(/\s+/).filter((word) => word.length > 0).length
 
     return {
       words,


### PR DESCRIPTION
Fixes word counting to properly exclude markdown syntax characters.

## Problem

The word counter was counting markdown syntax characters like `#`, `##`, `-`, `*`, etc. as separate words, resulting in inflated word counts.

## Solution

Updated `WordCounter.calculateCounts()` to strip markdown syntax before counting words:

- **Heading markers**: `#`, `##`, `###`, etc.
- **List markers**: `-`, `*`, `+`, numbered lists (`1.`, `2.`, etc.)
- **Bold/italic markers**: `**text**`, `__text__`, `*text*`, `_text_`
- **Strikethrough**: `~~text~~`
- **Blockquote markers**: `>`
- **Horizontal rules**: `---`, `***`, `___`

## Testing

Added 8 new comprehensive test cases:
- Heading markers
- List markers (unordered and numbered)
- Bold and italic formatting
- Strikethrough
- Blockquotes
- Horizontal rules
- Complex markdown documents

✅ All 286 tests passing
✅ ESLint clean
✅ Build successful

## Example

**Before**: `# Hello World` counted as 3 words (`#`, `Hello`, `World`)  
**After**: `# Hello World` counts as 2 words (`Hello`, `World`)

**Before**: `- List item` counted as 3 words (`-`, `List`, `item`)  
**After**: `- List item` counts as 2 words (`List`, `item`)