### PR TITLE
fix: treat em-dashes and en-dashes as word separators

### DIFF
--- a/src/core/WordCounter.test.ts
+++ b/src/core/WordCounter.test.ts
@@ -87,6 +87,18 @@ describe('WordCounter', () => {
       expect(result.words).toBe(4) // "Text before Text after"
     })
 
+    it('should treat em-dashes as word separators', () => {
+      const result = counter.countText('This is a test—and another test')
+
+      expect(result.words).toBe(7) // "This is a test and another test"
+    })
+
+    it('should handle en-dashes and other punctuation dashes', () => {
+      const result = counter.countText('Words connected–by en-dash and words—by em-dash')
+
+      expect(result.words).toBe(8) // Dashes treated as separators, hyphens kept in words
+    })
+
     it('should handle complex markdown with multiple syntax elements', () => {
       const text = `# Main Heading
 

--- a/src/core/WordCounter.ts
+++ b/src/core/WordCounter.ts
@@ -187,6 +187,10 @@ export class WordCounter {
     // Remove remaining standalone markdown characters that might be counted as words
     cleanedText = cleanedText.replace(/^[#*\-_>]+$/gm, '')
 
+    // Normalize punctuation dashes to spaces for word counting
+    // Em-dash (—), en-dash (–), and horizontal bar (―) should separate words
+    cleanedText = cleanedText.replace(/[—–―]/g, ' ')
+
     // Count words: split by whitespace, filter empty strings
     const words = cleanedText.split(/\s+/).filter((word) => word.length > 0).length
 


### PR DESCRIPTION
Previously, punctuation dashes (em-dash —, en-dash –) were not treated as word separators, causing words like 'vector—a' to be counted as one word instead of two. This caused discrepancies with Obsidian's word counter.

Now normalizes em-dashes, en-dashes, and horizontal bars to spaces before counting words, matching Obsidian's behavior.

Added tests to verify punctuation dashes are handled correctly.

# Pull Request

## Description
Brief description of the changes in this PR.

## Related Issues
Fixes #(issue number)
Closes #(issue number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made
- Change 1
- Change 2
- Change 3

## Testing
Describe how you tested these changes:
- [ ] Manual testing in Obsidian
- [ ] Added/updated unit tests
- [ ] Tested on multiple platforms (if applicable)

## Screenshots (if applicable)
Add screenshots to demonstrate UI changes.

## Checklist
- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if needed)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated CHANGELOG.md with my changes

## Additional Notes
Any additional information that reviewers should know.
