### PR TITLE
feat: file splitting and merging

### DIFF
--- a/src/core/FileSplitter.test.ts
+++ b/src/core/FileSplitter.test.ts
@@ -129,10 +129,7 @@ describe('FileSplitter', () => {
       await splitter.splitAtCursor(mockEditor, sourceFile)
 
       expect(setValueSpy).toHaveBeenCalledWith('Line 1')
-      expect(createSpy).toHaveBeenCalledWith(
-        'projects/novel/chapters/ch1 2.md',
-        'Line 2\nLine 3',
-      )
+      expect(createSpy).toHaveBeenCalledWith('projects/novel/chapters/ch1 2.md', 'Line 2\nLine 3')
     })
 
     it('inserts the new file immediately after the source in fileOrder', async () => {
@@ -176,10 +173,7 @@ describe('FileSplitter', () => {
 
       await splitter.splitAtCursor(mockEditor, sourceFile)
 
-      expect(createSpy).toHaveBeenCalledWith(
-        'projects/novel/chapters/ch1 3.md',
-        expect.any(String),
-      )
+      expect(createSpy).toHaveBeenCalledWith('projects/novel/chapters/ch1 3.md', expect.any(String))
     })
   })
 
@@ -195,10 +189,7 @@ describe('FileSplitter', () => {
 
       await splitter.mergeInto(sourceFile, targetFile)
 
-      expect(modifySpy).toHaveBeenCalledWith(
-        targetFile,
-        'First chapter\n\n---\n\nSecond chapter',
-      )
+      expect(modifySpy).toHaveBeenCalledWith(targetFile, 'First chapter\n\n---\n\nSecond chapter')
     })
 
     it('deletes the source file from the vault', async () => {

--- a/src/core/FileSplitter.test.ts
+++ b/src/core/FileSplitter.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FileSplitter } from '@/core/FileSplitter'
+import type { ProjectManager } from '@/core/ProjectManager'
+import type { Project } from '@/types/types'
+
+import type { App, Editor, TFile, TFolder, Vault, Workspace } from 'obsidian'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const makeProject = (overrides: Partial<Project> = {}): Project => ({
+  id: 'proj-1',
+  name: 'Test Project',
+  rootPath: 'projects/novel',
+  contentFolders: ['chapters'],
+  sourceFolders: ['research'],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  fileOrder: ['projects/novel/chapters/ch1.md'],
+  ...overrides,
+})
+
+const makeFile = (path: string, content = 'content'): TFile =>
+  ({
+    path,
+    name: path.split('/').pop()!,
+    basename: path.split('/').pop()!.replace(/\.md$/, ''),
+    extension: 'md',
+    parent: {
+      path: path.split('/').slice(0, -1).join('/'),
+      children: [],
+    } as unknown as TFolder,
+    vault: {} as Vault,
+    stat: { ctime: 0, mtime: 0, size: content.length },
+  }) as unknown as TFile
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('FileSplitter', () => {
+  let splitter: FileSplitter
+  let mockApp: App
+  let mockProjectManager: ProjectManager
+  let project: Project
+
+  const vaultFiles = new Map<string, string>()
+
+  beforeEach(() => {
+    project = makeProject()
+    vaultFiles.clear()
+    vaultFiles.set('projects/novel/chapters/ch1.md', 'First half content')
+
+    const mockVault = {
+      getAbstractFileByPath: (path: string) => {
+        if (vaultFiles.has(path)) return makeFile(path, vaultFiles.get(path))
+        return null
+      },
+      create: vi.fn(async (path: string, content: string) => {
+        vaultFiles.set(path, content)
+        return makeFile(path, content)
+      }),
+      modify: vi.fn(async (file: TFile, content: string) => {
+        vaultFiles.set(file.path, content)
+      }),
+      delete: vi.fn(async (file: TFile) => {
+        vaultFiles.delete(file.path)
+      }),
+      read: vi.fn(async (file: TFile) => vaultFiles.get(file.path) ?? ''),
+    } as unknown as Vault
+
+    const mockLeaf = {
+      openFile: vi.fn(async () => {}),
+    }
+
+    const mockWorkspace = {
+      getLeaf: vi.fn(() => mockLeaf),
+      getLeavesOfType: vi.fn(() => []),
+    } as unknown as Workspace
+
+    mockApp = {
+      vault: mockVault,
+      workspace: mockWorkspace,
+    } as unknown as App
+
+    mockProjectManager = {
+      getActiveProject: vi.fn(() => project),
+      reorderProjectFiles: vi.fn(async (_id: string, order: string[]) => {
+        project = { ...project, fileOrder: order }
+      }),
+    } as unknown as ProjectManager
+
+    splitter = new FileSplitter(mockApp, mockProjectManager)
+  })
+
+  // ── splitAtCursor ──────────────────────────────────────────────────────────
+
+  describe('splitAtCursor', () => {
+    it('splits content at cursor and creates a sibling file', async () => {
+      const sourceFile = makeFile('projects/novel/chapters/ch1.md', 'Line 1\nLine 2\nLine 3')
+      const mockEditor = {
+        getCursor: vi.fn(() => ({ line: 1, ch: 0 })),
+        getValue: vi.fn(() => 'Line 1\nLine 2\nLine 3'),
+        setValue: vi.fn(),
+      } as unknown as Editor
+
+      await splitter.splitAtCursor(mockEditor, sourceFile)
+
+      // Original file is trimmed to the first part
+      expect(mockEditor.setValue).toHaveBeenCalledWith('Line 1')
+
+      // New file created with content from cursor onward
+      expect(mockApp.vault.create).toHaveBeenCalledWith(
+        'projects/novel/chapters/ch1 2.md',
+        'Line 2\nLine 3',
+      )
+    })
+
+    it('inserts the new file immediately after the source in fileOrder', async () => {
+      const sourceFile = makeFile('projects/novel/chapters/ch1.md', 'Line 1\nLine 2')
+      const mockEditor = {
+        getCursor: vi.fn(() => ({ line: 1, ch: 0 })),
+        getValue: vi.fn(() => 'Line 1\nLine 2'),
+        setValue: vi.fn(),
+      } as unknown as Editor
+
+      await splitter.splitAtCursor(mockEditor, sourceFile)
+
+      expect(mockProjectManager.reorderProjectFiles).toHaveBeenCalledWith('proj-1', [
+        'projects/novel/chapters/ch1.md',
+        'projects/novel/chapters/ch1 2.md',
+      ])
+    })
+
+    it('shows a notice and does nothing when cursor is at the end', async () => {
+      const sourceFile = makeFile('projects/novel/chapters/ch1.md', 'All content')
+      const mockEditor = {
+        getCursor: vi.fn(() => ({ line: 1, ch: 0 })),
+        getValue: vi.fn(() => 'All content\n'),
+        setValue: vi.fn(),
+      } as unknown as Editor
+
+      await splitter.splitAtCursor(mockEditor, sourceFile)
+
+      // Nothing after cursor → no file created
+      expect(mockApp.vault.create).not.toHaveBeenCalled()
+    })
+
+    it('generates a unique name when the default sibling name is taken', async () => {
+      // "ch1 2.md" already exists
+      vaultFiles.set('projects/novel/chapters/ch1 2.md', 'existing')
+
+      const sourceFile = makeFile('projects/novel/chapters/ch1.md', 'Line 1\nLine 2')
+      const mockEditor = {
+        getCursor: vi.fn(() => ({ line: 1, ch: 0 })),
+        getValue: vi.fn(() => 'Line 1\nLine 2'),
+        setValue: vi.fn(),
+      } as unknown as Editor
+
+      await splitter.splitAtCursor(mockEditor, sourceFile)
+
+      expect(mockApp.vault.create).toHaveBeenCalledWith(
+        'projects/novel/chapters/ch1 3.md',
+        expect.any(String),
+      )
+    })
+  })
+
+  // ── mergeInto ─────────────────────────────────────────────────────────────
+
+  describe('mergeInto', () => {
+    it('appends source content to target with a separator', async () => {
+      const sourceFile = makeFile('projects/novel/chapters/ch2.md', 'Second chapter')
+      const targetFile = makeFile('projects/novel/chapters/ch1.md', 'First chapter')
+
+      vaultFiles.set(sourceFile.path, 'Second chapter')
+      vaultFiles.set(targetFile.path, 'First chapter')
+
+      await splitter.mergeInto(sourceFile, targetFile)
+
+      expect(mockApp.vault.modify).toHaveBeenCalledWith(
+        targetFile,
+        'First chapter\n\n---\n\nSecond chapter',
+      )
+    })
+
+    it('deletes the source file from the vault', async () => {
+      const sourceFile = makeFile('projects/novel/chapters/ch2.md', 'Source')
+      const targetFile = makeFile('projects/novel/chapters/ch1.md', 'Target')
+
+      vaultFiles.set(sourceFile.path, 'Source')
+      vaultFiles.set(targetFile.path, 'Target')
+
+      await splitter.mergeInto(sourceFile, targetFile)
+
+      expect(mockApp.vault.delete).toHaveBeenCalledWith(sourceFile)
+    })
+
+    it('removes the source file from fileOrder', async () => {
+      project = makeProject({
+        fileOrder: [
+          'projects/novel/chapters/ch1.md',
+          'projects/novel/chapters/ch2.md',
+        ],
+      })
+      vi.mocked(mockProjectManager.getActiveProject).mockReturnValue(project)
+
+      const sourceFile = makeFile('projects/novel/chapters/ch2.md', 'Source')
+      const targetFile = makeFile('projects/novel/chapters/ch1.md', 'Target')
+
+      vaultFiles.set(sourceFile.path, 'Source')
+      vaultFiles.set(targetFile.path, 'Target')
+
+      await splitter.mergeInto(sourceFile, targetFile)
+
+      expect(mockProjectManager.reorderProjectFiles).toHaveBeenCalledWith('proj-1', [
+        'projects/novel/chapters/ch1.md',
+      ])
+    })
+
+    it('refuses to merge a file into itself', async () => {
+      const file = makeFile('projects/novel/chapters/ch1.md', 'Content')
+      vaultFiles.set(file.path, 'Content')
+
+      await splitter.mergeInto(file, file)
+
+      expect(mockApp.vault.modify).not.toHaveBeenCalled()
+      expect(mockApp.vault.delete).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/core/FileSplitter.test.ts
+++ b/src/core/FileSplitter.test.ts
@@ -20,19 +20,23 @@ const makeProject = (overrides: Partial<Project> = {}): Project => ({
   ...overrides,
 })
 
-const makeFile = (path: string, content = 'content'): TFile =>
-  ({
+const makeFile = (path: string, content = 'content'): TFile => {
+  const parent = {
+    path: path.split('/').slice(0, -1).join('/'),
+    children: [],
+    // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+  } as unknown as TFolder
+  return {
     path,
     name: path.split('/').pop()!,
     basename: path.split('/').pop()!.replace(/\.md$/, ''),
     extension: 'md',
-    parent: {
-      path: path.split('/').slice(0, -1).join('/'),
-      children: [],
-    } as unknown as TFolder,
+    parent,
     vault: {} as Vault,
     stat: { ctime: 0, mtime: 0, size: content.length },
-  }) as unknown as TFile
+    // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+  } as unknown as TFile
+}
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -42,6 +46,14 @@ describe('FileSplitter', () => {
   let mockProjectManager: ProjectManager
   let project: Project
 
+  // Named spy references used in expect() calls (avoids unbound-method lint)
+  let createSpy: ReturnType<typeof vi.fn>
+  let modifySpy: ReturnType<typeof vi.fn>
+  let trashFileSpy: ReturnType<typeof vi.fn>
+  let readSpy: ReturnType<typeof vi.fn>
+  let reorderSpy: ReturnType<typeof vi.fn>
+  let getActiveProjectSpy: ReturnType<typeof vi.fn>
+
   const vaultFiles = new Map<string, string>()
 
   beforeEach(() => {
@@ -49,43 +61,54 @@ describe('FileSplitter', () => {
     vaultFiles.clear()
     vaultFiles.set('projects/novel/chapters/ch1.md', 'First half content')
 
+    createSpy = vi.fn(async (path: string, content: string) => {
+      vaultFiles.set(path, content)
+      return makeFile(path, content)
+    })
+    modifySpy = vi.fn(async (file: TFile, content: string) => {
+      vaultFiles.set(file.path, content)
+    })
+    trashFileSpy = vi.fn(async (file: TFile) => {
+      vaultFiles.delete(file.path)
+    })
+    readSpy = vi.fn(async (file: TFile) => vaultFiles.get(file.path) ?? '')
+
     const mockVault = {
       getAbstractFileByPath: (path: string) => {
         if (vaultFiles.has(path)) return makeFile(path, vaultFiles.get(path))
         return null
       },
-      create: vi.fn(async (path: string, content: string) => {
-        vaultFiles.set(path, content)
-        return makeFile(path, content)
-      }),
-      modify: vi.fn(async (file: TFile, content: string) => {
-        vaultFiles.set(file.path, content)
-      }),
-      delete: vi.fn(async (file: TFile) => {
-        vaultFiles.delete(file.path)
-      }),
-      read: vi.fn(async (file: TFile) => vaultFiles.get(file.path) ?? ''),
+      create: createSpy,
+      modify: modifySpy,
+      read: readSpy,
     } as unknown as Vault
 
-    const mockLeaf = {
-      openFile: vi.fn(async () => {}),
-    }
+    const openFileSpy = vi.fn(async () => {})
+    const mockLeaf = { openFile: openFileSpy }
 
     const mockWorkspace = {
       getLeaf: vi.fn(() => mockLeaf),
       getLeavesOfType: vi.fn(() => []),
     } as unknown as Workspace
 
+    const mockFileManager = {
+      trashFile: trashFileSpy,
+    }
+
     mockApp = {
       vault: mockVault,
       workspace: mockWorkspace,
+      fileManager: mockFileManager,
     } as unknown as App
 
+    getActiveProjectSpy = vi.fn(() => project)
+    reorderSpy = vi.fn(async (_id: string, order: string[]) => {
+      project = { ...project, fileOrder: order }
+    })
+
     mockProjectManager = {
-      getActiveProject: vi.fn(() => project),
-      reorderProjectFiles: vi.fn(async (_id: string, order: string[]) => {
-        project = { ...project, fileOrder: order }
-      }),
+      getActiveProject: getActiveProjectSpy,
+      reorderProjectFiles: reorderSpy,
     } as unknown as ProjectManager
 
     splitter = new FileSplitter(mockApp, mockProjectManager)
@@ -96,19 +119,17 @@ describe('FileSplitter', () => {
   describe('splitAtCursor', () => {
     it('splits content at cursor and creates a sibling file', async () => {
       const sourceFile = makeFile('projects/novel/chapters/ch1.md', 'Line 1\nLine 2\nLine 3')
+      const setValueSpy = vi.fn()
       const mockEditor = {
         getCursor: vi.fn(() => ({ line: 1, ch: 0 })),
         getValue: vi.fn(() => 'Line 1\nLine 2\nLine 3'),
-        setValue: vi.fn(),
+        setValue: setValueSpy,
       } as unknown as Editor
 
       await splitter.splitAtCursor(mockEditor, sourceFile)
 
-      // Original file is trimmed to the first part
-      expect(mockEditor.setValue).toHaveBeenCalledWith('Line 1')
-
-      // New file created with content from cursor onward
-      expect(mockApp.vault.create).toHaveBeenCalledWith(
+      expect(setValueSpy).toHaveBeenCalledWith('Line 1')
+      expect(createSpy).toHaveBeenCalledWith(
         'projects/novel/chapters/ch1 2.md',
         'Line 2\nLine 3',
       )
@@ -124,7 +145,7 @@ describe('FileSplitter', () => {
 
       await splitter.splitAtCursor(mockEditor, sourceFile)
 
-      expect(mockProjectManager.reorderProjectFiles).toHaveBeenCalledWith('proj-1', [
+      expect(reorderSpy).toHaveBeenCalledWith('proj-1', [
         'projects/novel/chapters/ch1.md',
         'projects/novel/chapters/ch1 2.md',
       ])
@@ -140,12 +161,10 @@ describe('FileSplitter', () => {
 
       await splitter.splitAtCursor(mockEditor, sourceFile)
 
-      // Nothing after cursor → no file created
-      expect(mockApp.vault.create).not.toHaveBeenCalled()
+      expect(createSpy).not.toHaveBeenCalled()
     })
 
     it('generates a unique name when the default sibling name is taken', async () => {
-      // "ch1 2.md" already exists
       vaultFiles.set('projects/novel/chapters/ch1 2.md', 'existing')
 
       const sourceFile = makeFile('projects/novel/chapters/ch1.md', 'Line 1\nLine 2')
@@ -157,7 +176,7 @@ describe('FileSplitter', () => {
 
       await splitter.splitAtCursor(mockEditor, sourceFile)
 
-      expect(mockApp.vault.create).toHaveBeenCalledWith(
+      expect(createSpy).toHaveBeenCalledWith(
         'projects/novel/chapters/ch1 3.md',
         expect.any(String),
       )
@@ -176,7 +195,7 @@ describe('FileSplitter', () => {
 
       await splitter.mergeInto(sourceFile, targetFile)
 
-      expect(mockApp.vault.modify).toHaveBeenCalledWith(
+      expect(modifySpy).toHaveBeenCalledWith(
         targetFile,
         'First chapter\n\n---\n\nSecond chapter',
       )
@@ -191,17 +210,14 @@ describe('FileSplitter', () => {
 
       await splitter.mergeInto(sourceFile, targetFile)
 
-      expect(mockApp.vault.delete).toHaveBeenCalledWith(sourceFile)
+      expect(trashFileSpy).toHaveBeenCalledWith(sourceFile)
     })
 
     it('removes the source file from fileOrder', async () => {
       project = makeProject({
-        fileOrder: [
-          'projects/novel/chapters/ch1.md',
-          'projects/novel/chapters/ch2.md',
-        ],
+        fileOrder: ['projects/novel/chapters/ch1.md', 'projects/novel/chapters/ch2.md'],
       })
-      vi.mocked(mockProjectManager.getActiveProject).mockReturnValue(project)
+      getActiveProjectSpy.mockReturnValue(project)
 
       const sourceFile = makeFile('projects/novel/chapters/ch2.md', 'Source')
       const targetFile = makeFile('projects/novel/chapters/ch1.md', 'Target')
@@ -211,9 +227,7 @@ describe('FileSplitter', () => {
 
       await splitter.mergeInto(sourceFile, targetFile)
 
-      expect(mockProjectManager.reorderProjectFiles).toHaveBeenCalledWith('proj-1', [
-        'projects/novel/chapters/ch1.md',
-      ])
+      expect(reorderSpy).toHaveBeenCalledWith('proj-1', ['projects/novel/chapters/ch1.md'])
     })
 
     it('refuses to merge a file into itself', async () => {
@@ -222,8 +236,8 @@ describe('FileSplitter', () => {
 
       await splitter.mergeInto(file, file)
 
-      expect(mockApp.vault.modify).not.toHaveBeenCalled()
-      expect(mockApp.vault.delete).not.toHaveBeenCalled()
+      expect(modifySpy).not.toHaveBeenCalled()
+      expect(trashFileSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/core/FileSplitter.ts
+++ b/src/core/FileSplitter.ts
@@ -1,4 +1,4 @@
-import { Notice, type App, type Editor, type TFile } from 'obsidian'
+import { Notice, TFile, type App, type Editor } from 'obsidian'
 
 import type { ProjectManager } from '@/core/ProjectManager'
 
@@ -82,7 +82,7 @@ export class FileSplitter {
     const merged = targetContent.trimEnd() + separator + sourceContent.trim()
 
     await this.app.vault.modify(targetFile, merged)
-    await this.app.vault.delete(sourceFile)
+    await this.app.fileManager.trashFile(sourceFile)
 
     // Remove source from fileOrder
     const project = this.projectManager.getActiveProject()
@@ -128,11 +128,10 @@ export class FileSplitter {
 
   private collectMarkdownFiles(folder: { children: unknown[] }, out: TFile[]): void {
     for (const child of folder.children) {
-      if ('children' in (child as object)) {
+      if (child !== null && typeof child === 'object' && 'children' in child) {
         this.collectMarkdownFiles(child as { children: unknown[] }, out)
-      } else {
-        const file = child as TFile
-        if (file.extension === 'md') out.push(file)
+      } else if (child instanceof TFile && child.extension === 'md') {
+        out.push(child)
       }
     }
   }

--- a/src/core/FileSplitter.ts
+++ b/src/core/FileSplitter.ts
@@ -1,0 +1,151 @@
+import { Notice, type App, type Editor, type TFile } from 'obsidian'
+
+import type { ProjectManager } from '@/core/ProjectManager'
+
+/**
+ * Handles file split and merge operations for the active project.
+ */
+export class FileSplitter {
+  constructor(
+    private app: App,
+    private projectManager: ProjectManager,
+  ) {}
+
+  /**
+   * Split the active file at the editor cursor position.
+   *
+   * - Content before the cursor stays in the original file.
+   * - Content from the cursor onward moves into a newly created sibling file.
+   * - The new file is inserted into the project's fileOrder immediately after
+   *   the original.
+   */
+  async splitAtCursor(editor: Editor, sourceFile: TFile): Promise<void> {
+    const cursor = editor.getCursor()
+    const content = editor.getValue()
+    const lines = content.split('\n')
+
+    const before = lines.slice(0, cursor.line).join('\n')
+    const after = lines.slice(cursor.line).join('\n').trim()
+
+    if (!after) {
+      new Notice('Nothing after the cursor to split into a new note.')
+      return
+    }
+
+    // Generate a unique sibling file name
+    const folder = sourceFile.parent?.path ?? ''
+    const baseName = sourceFile.basename
+    const newPath = this.uniqueSiblingPath(folder, baseName)
+
+    // Write split content
+    editor.setValue(before)
+    const newFile = await this.app.vault.create(newPath, after)
+
+    // Update fileOrder: insert newPath directly after sourceFile.path
+    const project = this.projectManager.getActiveProject()
+    if (project) {
+      const order = project.fileOrder ? [...project.fileOrder] : []
+      const srcIdx = order.indexOf(sourceFile.path)
+      if (srcIdx !== -1) {
+        order.splice(srcIdx + 1, 0, newPath)
+      } else {
+        // Source wasn't in order yet; append new file after source at end
+        order.push(sourceFile.path, newPath)
+      }
+      await this.projectManager.reorderProjectFiles(project.id, order)
+    }
+
+    // Open the new file
+    const leaf = this.app.workspace.getLeaf(false)
+    await leaf.openFile(newFile)
+
+    new Notice(`Split into "${newFile.name}"`)
+  }
+
+  /**
+   * Merge sourceFile into targetFile.
+   *
+   * - Appends a separator and the source content to the target file.
+   * - Deletes the source file from the vault.
+   * - Removes the source file from the project's fileOrder.
+   */
+  async mergeInto(sourceFile: TFile, targetFile: TFile): Promise<void> {
+    if (sourceFile.path === targetFile.path) {
+      new Notice('Cannot merge a file into itself.')
+      return
+    }
+
+    const sourceContent = await this.app.vault.read(sourceFile)
+    const targetContent = await this.app.vault.read(targetFile)
+
+    const separator = '\n\n---\n\n'
+    const merged = targetContent.trimEnd() + separator + sourceContent.trim()
+
+    await this.app.vault.modify(targetFile, merged)
+    await this.app.vault.delete(sourceFile)
+
+    // Remove source from fileOrder
+    const project = this.projectManager.getActiveProject()
+    if (project?.fileOrder) {
+      const newOrder = project.fileOrder.filter((p) => p !== sourceFile.path)
+      await this.projectManager.reorderProjectFiles(project.id, newOrder)
+    }
+
+    // If the source file is open, open the target instead
+    const leaves = this.app.workspace.getLeavesOfType('markdown')
+    for (const leaf of leaves) {
+      const view = leaf.view as { file?: TFile }
+      if (view.file?.path === sourceFile.path) {
+        await leaf.openFile(targetFile)
+        break
+      }
+    }
+
+    new Notice(`Merged "${sourceFile.name}" into "${targetFile.name}"`)
+  }
+
+  /**
+   * Collect all markdown files belonging to the active project.
+   * Used to populate the merge target picker.
+   */
+  getProjectFiles(): TFile[] {
+    const project = this.projectManager.getActiveProject()
+    if (!project) return []
+
+    const allFolders = [...project.contentFolders, ...project.sourceFolders].map((rel) =>
+      rel ? `${project.rootPath}/${rel}` : project.rootPath,
+    )
+
+    const files: TFile[] = []
+    for (const folderPath of allFolders) {
+      const folder = this.app.vault.getAbstractFileByPath(folderPath)
+      if (folder && 'children' in folder) {
+        this.collectMarkdownFiles(folder as Parameters<typeof this.collectMarkdownFiles>[0], files)
+      }
+    }
+    return files
+  }
+
+  private collectMarkdownFiles(folder: { children: unknown[] }, out: TFile[]): void {
+    for (const child of folder.children) {
+      if ('children' in (child as object)) {
+        this.collectMarkdownFiles(child as { children: unknown[] }, out)
+      } else {
+        const file = child as TFile
+        if (file.extension === 'md') out.push(file)
+      }
+    }
+  }
+
+  /** Return a path that doesn't yet exist in the vault. */
+  private uniqueSiblingPath(folder: string, baseName: string): string {
+    const prefix = folder ? `${folder}/` : ''
+    let candidate = `${prefix}${baseName} 2.md`
+    let n = 2
+    while (this.app.vault.getAbstractFileByPath(candidate)) {
+      n++
+      candidate = `${prefix}${baseName} ${n}.md`
+    }
+    return candidate
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Notice, Plugin } from 'obsidian'
 
+import { FileSplitter } from '@/core/FileSplitter'
 import { FlowMode } from '@/core/FlowMode'
 import { FolderManager } from '@/core/FolderManager'
 import { HierarchicalCounter } from '@/core/HierarchicalCounter'
@@ -27,6 +28,7 @@ export default class LighthousePlugin extends Plugin {
   workspaceManager!: WorkspaceManager
   sessionTracker!: WritingSessionTracker
   binaryManager!: BinaryManager
+  fileSplitter!: FileSplitter
 
   async onload() {
     // Initialize core services
@@ -44,6 +46,7 @@ export default class LighthousePlugin extends Plugin {
     this.sessionTracker = new WritingSessionTracker(this)
     this.binaryManager = new BinaryManager(this)
     await this.projectManager.initialize()
+    this.fileSplitter = new FileSplitter(this.app, this.projectManager)
     // Settings are owned by ProjectStorage — sync the plugin reference
     this.settings = this.projectManager.getSettings()
 
@@ -114,6 +117,23 @@ export default class LighthousePlugin extends Plugin {
       callback: () => {
         const modal = new ProjectSwitcherModal(this)
         modal.open()
+      },
+    })
+
+    // Split the active note at the cursor position
+    this.addCommand({
+      id: 'split-note-at-cursor',
+      name: 'Split note at cursor',
+      editorCallback: (editor, ctx) => {
+        if (!ctx.file) {
+          new Notice('No active file to split.')
+          return
+        }
+        if (!this.projectManager.getActiveProject()) {
+          new Notice('No active Lighthouse project.')
+          return
+        }
+        void this.fileSplitter.splitAtCursor(editor, ctx.file)
       },
     })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,7 +130,7 @@ export default class LighthousePlugin extends Plugin {
           return
         }
         if (!this.projectManager.getActiveProject()) {
-          new Notice('No active Lighthouse project.')
+          new Notice('No active project — open or create one first.')
           return
         }
         void this.fileSplitter.splitAtCursor(editor, ctx.file)

--- a/src/ui/modals/MergeModal.ts
+++ b/src/ui/modals/MergeModal.ts
@@ -1,0 +1,34 @@
+import { FuzzySuggestModal, type App, type TFile } from 'obsidian'
+
+/**
+ * A fuzzy-search modal that lets the user pick a target file to merge into.
+ */
+export class MergeModal extends FuzzySuggestModal<TFile> {
+  private files: TFile[]
+  private onChoose: (target: TFile) => void
+
+  constructor(app: App, sourceFile: TFile, files: TFile[], onChoose: (target: TFile) => void) {
+    super(app)
+    // Exclude the source file from the list of merge targets
+    this.files = files.filter((f) => f.path !== sourceFile.path)
+    this.onChoose = onChoose
+    this.setPlaceholder(`Merge "${sourceFile.basename}" into…`)
+    this.setInstructions([
+      { command: '↑↓', purpose: 'navigate' },
+      { command: '↵', purpose: 'merge' },
+      { command: 'esc', purpose: 'cancel' },
+    ])
+  }
+
+  getItems(): TFile[] {
+    return this.files
+  }
+
+  getItemText(file: TFile): string {
+    return file.path
+  }
+
+  onChooseItem(file: TFile): void {
+    this.onChoose(file)
+  }
+}

--- a/src/ui/views/ProjectExplorer.svelte
+++ b/src/ui/views/ProjectExplorer.svelte
@@ -7,6 +7,7 @@
   import type { Project } from '@/types/types'
   import TreeNodeComponent from '@/ui/components/TreeNode.svelte'
   import { FileGoalModal } from '@/ui/modals/FileGoalModal'
+  import { MergeModal } from '@/ui/modals/MergeModal'
   import { ProjectSwitcherModal } from '@/ui/modals/ProjectSwitcher'
   import { reorderPaths, sortByFileOrder } from '@/utils/fileOrder'
 
@@ -357,6 +358,19 @@
                 updatedAt: new Date().toISOString(),
               })
               await loadFileWordCounts(currentProject)
+            }).open()
+          })
+      })
+
+      menu.addItem((item) => {
+        item
+          .setTitle('Merge into…')
+          .setIcon('git-merge')
+          .onClick(() => {
+            const sourceFile = file as TFile
+            const projectFiles = plugin.fileSplitter.getProjectFiles()
+            new MergeModal(plugin.app, sourceFile, projectFiles, (target) => {
+              void plugin.fileSplitter.mergeInto(sourceFile, target)
             }).open()
           })
       })


### PR DESCRIPTION
Closes #12

## Summary

Implements the two document-level restructuring operations described in the issue.

### Split at cursor
- New command **"Split note at cursor"** available in the command palette
- Content before the cursor stays in the original file; content from the cursor line onward moves to a new sibling file
- New file is auto-named `{original} 2.md` (increments to avoid collisions)
- The new file is inserted into the project's `fileOrder` immediately after the source file

### Merge into…
- New **"Merge into…"** option in the Project Explorer right-click menu (files only)
- Opens a fuzzy-search picker scoped to the current project's files
- Source content is appended to the target with a `---` separator
- Source file is deleted via `fileManager.trashFile()` (respects user trash preference)
- Source is removed from `fileOrder`; if it was open in a tab it's replaced with the target

## Files changed
- `src/core/FileSplitter.ts` — Core split/merge logic
- `src/ui/modals/MergeModal.ts` — Fuzzy-search target picker
- `src/main.ts` — Registers the split command
- `src/ui/views/ProjectExplorer.svelte` — Adds merge context menu item

## Tests
8 new unit tests covering: split content, fileOrder insertion, empty-after-cursor guard, unique name generation, merge content, vault deletion, fileOrder removal, and self-merge guard.