### PR TITLE
Rewrite README, update install flow, add plugin comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Lighthouse
+<div align="center">
+  <img src="assets/icon-app-tile.svg" alt="Lighthouse" width="96" height="96" />
 
-<img align="right" src="docs/src/assets/lighthouse.jpeg" alt="Lighthouse" width="300"/>
+  # Lighthouse
+
+  ### Project-based writing for Obsidian
+
+  [![GitHub release](https://img.shields.io/github/v/release/benjamincassidy/lighthouse?label=release)](https://github.com/benjamincassidy/lighthouse/releases/latest)
+  [![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=downloads&query=%24%5B%27lighthouse%27%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json)](https://community.obsidian.md/plugins/lighthouse)
+  [![License: MIT](https://img.shields.io/badge/license-MIT-b45309)](LICENSE)
+
+  [Documentation](https://benjamincassidy.github.io/lighthouse/) · [Community Plugin listing](https://community.obsidian.md/plugins/lighthouse) · [Report an issue](https://github.com/benjamincassidy/lighthouse/issues)
+</div>
+
+<br />
 
 > "It was done; it was finished. Yes, she thought, laying down her brush in extreme fatigue, I have had my vision."
 > — Virginia Woolf, *To the Lighthouse*
 
-<br />
-
-### Project-based writing for Obsidian.
-
-Lighthouse brings professional writing project management to Obsidian, inspired by Ulysses but without sacrificing Obsidian's power and flexibility. Perfect for novelists, academic writers, and anyone working on long-form writing projects.
-
-<br clear="right"/>
-
----
-
-## 📖 [Full Documentation](https://benjamincassidy.github.io/lighthouse/)
-
-Visit the [complete documentation site](https://benjamincassidy.github.io/lighthouse/) for detailed guides, tutorials, and reference materials.
+Lighthouse brings the focus of a dedicated writing app to Obsidian, inspired by Ulysses but without giving up Obsidian's power and flexibility. One command opens a dedicated Library and Inspector for a project — groups, goals, pacing, and focus, all built on plain markdown files in your vault. No lock-in, no proprietary format.
 
 ## Screenshots
 
@@ -38,76 +38,76 @@ Visit the [complete documentation site](https://benjamincassidy.github.io/lighth
 
 ## Features
 
-### ✅ Implemented
-
 **Writing Workspace**
-- **The Library** — A Ulysses-style Groups & Sheets browser in the left sidebar, replacing Obsidian's file explorer for the duration; drag-and-drop to reorder groups and sheets
-- **The Inspector** — Right-sidebar panel with Overview (goal ring, writing heatmap, streak), Stats (live counts, pacing), and Outline tabs
-- **One-command layout** — Toggle the whole workspace on/off from the ribbon; native file explorer is restored automatically on exit
+- The Library — a Ulysses-style Groups & Sheets browser in the left sidebar, replacing Obsidian's file explorer for the duration; drag-and-drop to reorder groups and sheets
+- The Inspector — right-sidebar panel with Overview (goal ring, writing heatmap, streak), Stats (live counts, pacing), and Outline tabs
+- One-command layout — toggle the whole workspace on/off from the ribbon; the native file explorer is restored automatically on exit
 
 **Project Management**
-- **Multiple Projects** — Create and manage independent writing projects, each with its own configuration
-- **Groups & Extras** — Organize a project into nestable Groups with custom icons; a built-in Extras group holds research and notes excluded from word counts
-- **Project Switcher** — Fuzzy-search modal to jump between projects instantly
+- Multiple projects — create and manage independent writing projects, each with its own configuration
+- Groups & Extras — organize a project into nestable Groups with custom icons; a built-in Extras group holds research and notes excluded from word counts
+- Project switcher — fuzzy-search modal to jump between projects instantly
 
 **Word Counting**
-- **Smart hierarchical counts** — Real-time word counts at file, group, and project levels
-- **Per-file and per-group goals** — Set individual targets on files or groups with inline progress rings
-- **Word count goal directions** — *At least* (minimum target) or *at most* (word limit / trim mode)
-- **Status bar count** — Live word count visible at the bottom of every window
+- Smart hierarchical counts — real-time word counts at file, group, and project levels
+- Per-file and per-group goals — set individual targets on files or groups with inline progress rings
+- Word count goal directions — at least (minimum target) or at most (word limit / trim mode)
+- Status bar count — live word count visible at the bottom of every window
 
 **Progress & Pacing**
-- **Deadline tracking** — Set a target finish date; see words/day needed and days remaining
-- **Adaptive daily pace** — Required daily target recalculates automatically as you write over or under the target
-- **Writing activity heatmap** — GitHub-style calendar showing 13 weeks of daily output with variable-size circles
-- **Writing streak** — Current streak and personal best; rest days keep the chain alive
-- **7-day rolling average** — On-pace / behind-pace indicator against your required daily target
-- **Read/speak time** — Estimated reading time (250 wpm) and speaking time (130 wpm) for the project total
+- Deadline tracking — set a target finish date; see words/day needed and days remaining
+- Adaptive daily pace — required daily target recalculates automatically as you write over or under the target
+- Writing activity heatmap — a 13-week calendar of daily output with variable-size circles
+- Writing streak — current streak and personal best; rest days keep the chain alive
+- 7-day rolling average — on-pace / behind-pace indicator against your required daily target
+- Read/speak time — estimated reading time (250 wpm) and speaking time (130 wpm) for the project total
 
 **Export & Editing**
-- **Compile & Export** — PDF (via Typst), DOCX and EPUB (via Pandoc), or plain Markdown, with built-in style presets and paper sizes
-- **Citations** — Per-project bibliography and CSL citation style, with 10 bundled styles and the ability to download thousands more
-- **Split & Merge** — Split a note at the cursor into a new sibling file; merge one note into another from its context menu
+- Compile & export — PDF (via Typst), DOCX and EPUB (via Pandoc), or plain Markdown, with built-in style presets and paper sizes
+- Citations — per-project bibliography and CSL citation style, with 10 bundled styles and the ability to download thousands more
+- Split & merge — split a note at the cursor into a new sibling file; merge one note into another from its context menu
 
 **Flow Mode**
 - Hides sidebars, ribbon, status bar, tabs, breadcrumbs, and navigation
 - Optional typewriter scroll, custom font, line height, and line width settings
 
-### 🚧 Planned
+### Roadmap
 
-- **Manuscript Mode** — Continuous read-only multi-file view for reading your whole draft as one document
-- **Project-wide Outline** — Cross-file heading tree for navigation, beyond the current per-file Outline tab
-- **Dataview Integration** — Enhanced Inspector queries
-- **Templater Integration** — Project-aware template variables
-
-## Development Status
-
-**Active development:** All features listed above are implemented and tested. The plugin is ready for daily use. The Community Plugin submission is in progress.
+- Manuscript Mode — continuous read-only multi-file view for reading your whole draft as one document
+- Project-wide Outline — cross-file heading tree for navigation, beyond the current per-file Outline tab
+- Dataview integration — enhanced Inspector queries
+- Templater integration — project-aware template variables
 
 ## Quick Start
 
 1. **Create a project** — Command Palette → `Lighthouse: Create new project`
-2. **Open the Writing Workspace** — Click the compass icon in the ribbon
-3. **Add Groups** — Organize your writing into Groups in the Library; research and notes go in the built-in Extras group
-4. **Set a goal (optional)** — Edit the project and add a word count goal and deadline
+2. **Open the Writing Workspace** — click the compass icon in the ribbon
+3. **Add Groups** — organize your writing into Groups in the Library; research and notes go in the built-in Extras group
+4. **Set a goal (optional)** — edit the project and add a word count goal and deadline
 5. **Start writing** — Lighthouse tracks everything automatically, with live stats in the Inspector
+
+See the [Getting Started guide](https://benjamincassidy.github.io/lighthouse/getting-started/introduction/) for the full walkthrough.
+
+## Installation
+
+Open the [Lighthouse listing](https://community.obsidian.md/plugins/lighthouse) on the Obsidian Community Plugins website and click **Add to Obsidian** — this opens Obsidian directly to the install page. See the [installation guide](https://benjamincassidy.github.io/lighthouse/getting-started/installation/) for the in-app browse method and manual installation.
 
 ## Contributing
 
-Contributions welcome! This is an early-stage project. See [LIGHTHOUSE_PROJECT_BRIEF.md](LIGHTHOUSE_PROJECT_BRIEF.md) for architecture and design decisions.
+Contributions are welcome — bug reports, feature suggestions, and pull requests. Open an [issue](https://github.com/benjamincassidy/lighthouse/issues) to start a discussion before larger changes.
 
 ## Support
 
 If you find Lighthouse helpful, consider:
-- ⭐ Starring the repository
-- 💝 [Sponsoring on GitHub](https://github.com/sponsors/benjamincassidy)
-- 🐛 Reporting bugs and suggesting features
-- 📖 Improving documentation
+- Starring the repository
+- [Sponsoring on GitHub](https://github.com/sponsors/benjamincassidy)
+- Reporting bugs and suggesting features
+- Improving documentation
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT License — see [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 
-- Built for the [Obsidian](https://obsidian.md/) community
+Built for the [Obsidian](https://obsidian.md/) community.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -69,6 +69,10 @@ export default defineConfig({
 						{ label: 'Troubleshooting', slug: 'reference/troubleshooting' },
 					],
 				},
+				{
+					label: 'Comparison',
+					items: [{ label: 'Lighthouse vs. Other Plugins', slug: 'comparison' }],
+				},
 			],
 			customCss: ['./src/styles/custom.css'],
 		}),

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -1,0 +1,33 @@
+---
+title: Lighthouse vs. Other Plugins
+description: How Lighthouse compares to other long-form writing plugins for Obsidian
+---
+
+Obsidian has a genuinely good crop of long-form writing plugins now, and none of them are wrong — they're built for different writers. This page is an honest comparison, not a sales pitch, so you can figure out which one actually fits how you work.
+
+## At a glance
+
+| Plugin | Version | Last release | File format | Best for |
+| --- | --- | --- | --- | --- |
+| **Lighthouse** | 1.3.0 | Jul 2026 | Plain markdown | Novelists, academics, and technical writers who want a focused, Ulysses-style workspace without leaving Obsidian |
+| [Longform](https://github.com/kevboh/longform) | 2.1.0 | Mar 2025 | Plain markdown | Writers who want the original, most established scene/project organizer |
+| [Inkswell](https://github.com/leethobbit/obsidian-inkswell-plugin) | 1.6.0 | Jul 2026 | Plain markdown | Plotters and series writers who want a full planning pipeline — beat sheets, story bible, revision audits |
+| [Books](https://github.com/jdsimcoe/obsidian-books) | 0.2.3 | Jun 2026 | Plain markdown | Writers who want a spine-style chapter organizer with manuscript styling and a research sidebar |
+| [Folio](https://github.com/danigarvire/Folio) | 1.1.2 | Jul 2026 | Plain markdown | Screenwriters and long-form writers who need Final Draft (`.fdx`) export |
+| [Colophon](https://github.com/davidgolding/obsidian-colophon) | 2.3.1 | Jul 2026 | Proprietary `.colophon` format | Writers who want a word-processor feel and don't mind leaving plain markdown behind |
+| [Book Smith](https://github.com/yeban8090/book-smith) | 1.0.5 | Jul 2025 | Plain markdown | Writers who want Pomodoro focus sessions and mobile sync alongside organization |
+
+*Versions and release dates reflect each plugin's GitHub release history as of mid-2026 — check the linked repo for the current state.*
+
+## Where Lighthouse fits
+
+If Longform is the established incumbent, Lighthouse is the alternative for people who found it to be more than they wanted to keep track of. That's not a knock on Longform — it's a capable, mature tool, and if its model of scenes, drafts, and compile steps clicks for how you think, it's worth using. But plenty of writers just want something closer to Ulysses: a clean two-pane workspace, a goal ring, a deadline, and nothing else competing for attention. That's the gap Lighthouse is built for.
+
+A few things set it apart from the rest of the field specifically:
+
+- **It's the only one of these built for academic and technical writers, not just fiction.** Lighthouse ships with real CSL citation support — a per-project bibliography, 10 bundled citation styles, and the ability to download thousands more — alongside the usual novel/screenplay use cases. If you're writing a thesis or coordinating technical docs, none of the other plugins here are aimed at you; Lighthouse is.
+- **Export goes through Typst, not just Pandoc.** PDF output is properly typeset rather than a markdown-to-PDF print job, plus DOCX and EPUB via Pandoc with style presets and paper sizes.
+- **The workspace fully takes over, then gives itself back.** One command replaces Obsidian's file explorer with the Library/Inspector pair for the duration of a writing session; exiting restores the native explorer automatically. It's meant to feel like a dedicated app while you're in it, and like plain Obsidian the moment you're not.
+- **Files never leave markdown.** Unlike Colophon's `.colophon` format, everything Lighthouse touches stays a normal `.md` file in your vault — no proprietary format, no lock-in, nothing that breaks if you stop using the plugin.
+
+Where Lighthouse doesn't try to compete: it has no story-bible or beat-sheet system like Inkswell, no screenplay export like Folio, and no built-in Pomodoro timer like Book Smith. If those are what you need, one of those tools will serve you better.

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -5,16 +5,31 @@ description: How to install Lighthouse in your Obsidian vault
 
 # Installing Lighthouse
 
-Lighthouse isn't yet listed in the Obsidian Community Plugins directory, so for now you'll install it manually.
+Lighthouse is available in Obsidian's Community Plugins directory. The fastest way to install it is straight from the web listing.
 
 ## Prerequisites
 
-- Obsidian v1.4.0 or later
+- Obsidian v1.12.0 or later
 - Basic familiarity with Obsidian's interface
+
+## Install from the Community Plugins website
+
+1. Open the [Lighthouse listing](https://community.obsidian.md/plugins/lighthouse) on the Obsidian Community Plugins website
+2. Click **Add to Obsidian** — this opens Obsidian directly and takes you to the plugin's install page
+3. Click **Install**, then **Enable**
+
+### Alternative: install from inside Obsidian
+
+1. Go to **Settings → Community plugins**
+2. Disable **Restricted Mode** if you haven't already
+3. Click **Browse** and search for "Lighthouse"
+4. Click **Install**, then **Enable**
 
 ## Manual Installation
 
-### Option 1: Download Release (Recommended)
+If you'd rather install the files by hand, or want a specific release:
+
+### Option 1: Download a Release
 
 1. Go to the [Lighthouse GitHub Releases](https://github.com/benjamincassidy/lighthouse/releases) page
 2. Download the latest release `.zip` file
@@ -76,7 +91,7 @@ Once installed and enabled, you should see:
 ### Plugin won't enable
 
 1. Check the Obsidian console (Cmd/Ctrl+Shift+I) for error messages
-2. Ensure you're running Obsidian v1.4.0 or later
+2. Ensure you're running Obsidian v1.12.0 or later
 3. Try reinstalling the plugin files
 4. Report persistent issues on [GitHub Issues](https://github.com/benjamincassidy/lighthouse/issues)
 

--- a/docs/src/content/docs/reference/troubleshooting.md
+++ b/docs/src/content/docs/reference/troubleshooting.md
@@ -10,17 +10,16 @@ description: Common issues and solutions
 ### Plugin won't appear after installation
 
 **Solution:**
-1. Verify all three files are present: `main.js`, `manifest.json`, `styles.css`
-2. Check folder name is exactly `lighthouse` (lowercase)
-3. Restart Obsidian completely
-4. Disable Restricted Mode in Settings → Community Plugins
+1. If you installed manually, verify all three files are present: `main.js`, `manifest.json`, `styles.css`, and that the folder name is exactly `lighthouse` (lowercase)
+2. Restart Obsidian completely
+3. Disable Restricted Mode in Settings → Community Plugins
 
 ### Plugin won't enable
 
 **Solution:**
 1. Open Developer Console (Cmd/Ctrl+Shift+I)
 2. Look for error messages
-3. Verify Obsidian version is 1.4.0 or later
+3. Verify Obsidian version is 1.12.0 or later
 4. Try reinstalling the plugin
 5. Report issues on [GitHub](https://github.com/benjamincassidy/lighthouse/issues)
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -7,6 +7,7 @@ const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`
 const gettingStarted = `${base}getting-started/introduction/`
+const comparisonUrl = `${base}comparison/`
 const githubUrl = 'https://github.com/benjamincassidy/lighthouse'
 const communityPluginsUrl = 'https://community.obsidian.md/plugins/lighthouse'
 
@@ -139,6 +140,9 @@ const features = [
       <p class="who-line">
         Novelists drafting long fiction, academics writing theses, technical writers coordinating
         docs — anyone with a long manuscript and a deadline.
+      </p>
+      <p class="who-compare">
+        <a class="link-arrow" href={comparisonUrl}>See how Lighthouse compares to other Obsidian writing plugins &rarr;</a>
       </p>
     </div>
 
@@ -467,6 +471,10 @@ const features = [
     line-height: 1.5;
     font-style: italic;
     margin: 0;
+  }
+
+  .who-compare {
+    margin: 24px 0 0;
   }
 
   /* Why band */


### PR DESCRIPTION
## Summary
- Rewrites the root README with the new brand mark, live release/downloads/license badges, and a corrected Installation section (dropped a stale invented BRAT reference and a broken link to a deleted file)
- Updates the install flow across the README and docs site to lead with the Community Plugins website's "Add to Obsidian" button, since Obsidian is steering installs there now; also fixes a stale minAppVersion reference in troubleshooting
- Adds a new "Lighthouse vs. Other Plugins" comparison page comparing Lighthouse against Longform, Inkswell, Books, Folio, Colophon, and Book Smith — version numbers and release dates pulled directly from each project's GitHub releases — plus a one-line link to it from the landing page's "Who it's for" section

## Test plan
- [x] `npm run lint` / `format:check` / `test` / `build` all pass (root project)
- [x] `docs` site builds clean (21 pages, up from 20)
- [x] Verified the new comparison page and landing-page link render correctly via a local preview + screenshots, in light mode
- [x] Confirmed the "Comparison" sidebar entry appears in the built HTML nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)