### PR TITLE
Add lighthouse-uncounted frontmatter flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ yarn-error.log*
 # screenshots/ itself is checked in and shown in the README
 .demo-vault
 .demo-vault-userdata
+ROADMAP.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `lighthouse-uncounted: true` YAML frontmatter flag to exclude an individual file from word-count totals, goals, and pacing — independent of Extras-folder membership
+
 ## [1.3.0] - 2026-07-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Lighthouse brings the focus of a dedicated writing app to Obsidian, inspired by 
 - Per-file and per-group goals — set individual targets on files or groups with inline progress rings
 - Word count goal directions — at least (minimum target) or at most (word limit / trim mode)
 - Status bar count — live word count visible at the bottom of every window
+- Per-file exclusion — tag any note `lighthouse-uncounted: true` to exclude it from totals without moving it into Extras
 
 **Progress & Pacing**
 - Deadline tracking — set a target finish date; see words/day needed and days remaining

--- a/docs/src/content/docs/core-concepts/word-counting.md
+++ b/docs/src/content/docs/core-concepts/word-counting.md
@@ -28,6 +28,18 @@ Lighthouse tracks words at three levels:
 
 Project totals include everything under the project root **except the Extras group**. This ensures your progress toward a goal reflects actual writing, not research notes. See [Groups & Extras](/core-concepts/groups/) for how Extras works.
 
+### Excluding an Individual File
+
+To exclude a single file from word-count totals without moving it into Extras, add this to its YAML frontmatter:
+
+```yaml
+---
+lighthouse-uncounted: true
+---
+```
+
+The file is skipped entirely from project and group totals — same treatment as an Extras file, just scoped to one note wherever it lives. Useful for a dedication, an epigraph, or any note you don't want counted toward a goal but don't want to relocate.
+
 ## What Gets Counted
 
 ### Included by default

--- a/src/core/HierarchicalCounter.test.ts
+++ b/src/core/HierarchicalCounter.test.ts
@@ -12,6 +12,7 @@ describe('HierarchicalCounter', () => {
   let wordCounter: WordCounter
   let folderManager: FolderManager
   let mockVault: Vault
+  let frontmatterMap: Map<string, Record<string, unknown>>
 
   type MockFile = TFile & { cachedRead?: () => Promise<string> }
   type MockFolder = TFolder
@@ -97,9 +98,17 @@ describe('HierarchicalCounter', () => {
       adapter: { constructor: Object },
     } as unknown as Vault
 
+    frontmatterMap = new Map()
+
     const mockApp = {
       workspace: {
         getActiveFile: () => null,
+      },
+      metadataCache: {
+        getFileCache: (file: TFile) => {
+          const frontmatter = frontmatterMap.get(file.path)
+          return frontmatter ? { frontmatter } : null
+        },
       },
     } as unknown as App
 
@@ -273,6 +282,44 @@ describe('HierarchicalCounter', () => {
       expect(result).toBeDefined()
       expect(result?.fileCount).toBeGreaterThan(0)
       expect(result?.wordCount).toBeGreaterThan(0)
+    })
+  })
+
+  describe('lighthouse-uncounted frontmatter flag', () => {
+    it('should exclude a file flagged lighthouse-uncounted: true from folder stats', async () => {
+      frontmatterMap.set('projects/novel/chapters/chapter1.md', { 'lighthouse-uncounted': true })
+
+      const result = await counter.countFolder('projects/novel/chapters')
+
+      expect(result?.fileCount).toBe(1) // chapter2 only
+    })
+
+    it('should not exclude a file without the flag set to true', async () => {
+      frontmatterMap.set('projects/novel/chapters/chapter1.md', { 'lighthouse-uncounted': false })
+
+      const result = await counter.countFolder('projects/novel/chapters')
+
+      expect(result?.fileCount).toBe(2)
+    })
+
+    it('should exclude flagged files from project totals', async () => {
+      const project = createTestProject()
+      frontmatterMap.set('projects/novel/chapters/chapter1.md', { 'lighthouse-uncounted': true })
+
+      const result = await counter.countProject(project)
+
+      expect(result.totalFiles).toBe(1) // chapter2 only; research excluded via Extras as usual
+    })
+
+    it('should be independent of Extras-folder exclusion', async () => {
+      const project = createTestProject()
+      // Flagging a file that's already excluded via Extras should be a no-op,
+      // not double-exclude or otherwise change behavior.
+      frontmatterMap.set('projects/novel/research/notes.md', { 'lighthouse-uncounted': true })
+
+      const result = await counter.countProject(project)
+
+      expect(result.totalFiles).toBe(2) // chapters unaffected either way
     })
   })
 })

--- a/src/core/HierarchicalCounter.ts
+++ b/src/core/HierarchicalCounter.ts
@@ -116,9 +116,18 @@ export class HierarchicalCounter {
   }
 
   /**
+   * True if the file's frontmatter has `lighthouse-uncounted: true`, excluding
+   * it from word-count totals independent of Extras-folder membership.
+   */
+  private isUncounted(file: TFile): boolean {
+    return this.app.metadataCache.getFileCache(file)?.frontmatter?.['lighthouse-uncounted'] === true
+  }
+
+  /**
    * Calculate stats for a folder and its children recursively.
    * Skips recursing into `excludePath` entirely (neither its words nor its
-   * files are counted) — used to exclude a project's Extras subtree.
+   * files are counted) — used to exclude a project's Extras subtree. Also
+   * skips individual files flagged `lighthouse-uncounted: true`.
    */
   private async calculateFolderStats(
     folder: TFolder,
@@ -140,6 +149,9 @@ export class HierarchicalCounter {
         wordCount += childStats.wordCount
         fileCount += childStats.fileCount
       } else if (this.isTFile(child) && child.extension === 'md') {
+        if (this.isUncounted(child)) {
+          continue
+        }
         // It's a markdown file
         const result = await this.countFile(child, options)
         if (result) {


### PR DESCRIPTION
## Summary
- Adds a `lighthouse-uncounted: true` YAML frontmatter flag that excludes an individual file from word-count totals, goals, and pacing — independent of Extras-folder membership. First item off `ROADMAP.md`.
- Hooks into `HierarchicalCounter.calculateFolderStats()`, following the exact same skip pattern already used for the Extras subtree exclusion.
- Documents the flag in the docs site's word-counting page and the README feature list.
- Adds the `[Unreleased]` CHANGELOG.md entry now (rather than holding it for release day).

Closes #60

## Test plan
- [x] 4 new unit tests: exclusion works, `false` doesn't falsely exclude, works through project-level aggregation, independent of Extras exclusion
- [x] `npm run lint` / `format:check` / `test` (319 passing) / `build` all pass
- [x] Docs site builds clean with the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)