### PR TITLE
Spike: Typst WASM feasibility (#77)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,9 +109,14 @@ export default tseslint.config(
         console: 'readonly',
         setTimeout: 'readonly',
         clearTimeout: 'readonly',
+        Buffer: 'readonly',
       },
     },
     rules: {
+      // Test files never ship in main.js (esbuild's entry point is src/main.ts
+      // only) — mobile-compatibility rules about real Node module access are
+      // noise here, not a real constraint.
+      'obsidianmd/no-nodejs-modules': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
       },
       "devDependencies": {
         "@eslint/json": "^0.14.0",
+        "@myriaddreamin/typst-ts-renderer": "^0.7.0",
+        "@myriaddreamin/typst-ts-web-compiler": "^0.7.0",
+        "@myriaddreamin/typst.ts": "^0.7.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
         "@tsconfig/svelte": "^5.0.6",
         "@types/node": "^22.10.6",
@@ -1559,6 +1562,42 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.1.10"
+      }
+    },
+    "node_modules/@myriaddreamin/typst-ts-renderer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.7.0.tgz",
+      "integrity": "sha512-3sXIGxZn9MufPrPn6251DeuLf2FIEILYNzY5lX0XOJmaIYqgvQ3qpfqkCjgQD+splBvt5R1N3BuuNFrZKsHhMw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@myriaddreamin/typst-ts-web-compiler": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@myriaddreamin/typst-ts-web-compiler/-/typst-ts-web-compiler-0.7.0.tgz",
+      "integrity": "sha512-nMwMcfOBy5pABPDuVM7/u8425SxhPUM+OJe6daqqgVOT3+neCTz4JKwx2L8XasfEHTNvd0cUI07LR9q5ADo7Gw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@myriaddreamin/typst.ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@myriaddreamin/typst.ts/-/typst.ts-0.7.0.tgz",
+      "integrity": "sha512-JtO5Td/1QesH1IBKAZtbayFNK8u2sl3iz18Y67uYqBEdcXiu3z+wpZcDDKlmVJvAcCgSjHTnuk6ZLfkYclrGGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "idb": "^7.1.1"
+      },
+      "peerDependencies": {
+        "@myriaddreamin/typst-ts-renderer": "^0.7.0",
+        "@myriaddreamin/typst-ts-web-compiler": "^0.7.0"
+      },
+      "peerDependenciesMeta": {
+        "@myriaddreamin/typst-ts-renderer": {
+          "optional": true
+        },
+        "@myriaddreamin/typst-ts-web-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5346,6 +5385,13 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/json": "^0.14.0",
+    "@myriaddreamin/typst-ts-renderer": "^0.7.0",
+    "@myriaddreamin/typst-ts-web-compiler": "^0.7.0",
+    "@myriaddreamin/typst.ts": "^0.7.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tsconfig/svelte": "^5.0.6",
     "@types/node": "^22.10.6",

--- a/src/core/tools/typstWasmSpike.test.ts
+++ b/src/core/tools/typstWasmSpike.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'fs'
+import { createRequire } from 'module'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Spike for GitHub issue #77 — proves that Typst can compile a document to
+ * PDF entirely in-process via WebAssembly, with no native binary, no
+ * subprocess, and no network call for the compiler itself.
+ *
+ * Deliberately NOT wired into any production export path yet — this is
+ * investigation, not implementation. See the issue for the open questions
+ * this doesn't yet answer (custom font injection, bundle size in the actual
+ * plugin build, load time inside Obsidian specifically).
+ *
+ * @myriaddreamin/typst-ts-node-compiler (the "Node" package upstream
+ * recommends) is a native N-API addon with platform-specific `.node`
+ * binaries — not usable from a single bundled plugin `main.js`. This test
+ * uses the browser/WASM packages instead (typst.ts + typst-ts-web-compiler),
+ * which is what Obsidian's Electron renderer can actually load in-process.
+ */
+describe('Typst WASM spike (issue #77)', () => {
+  it('compiles a trivial document to valid PDF bytes with no native binary', async () => {
+    const { createTypstCompiler } = await import('@myriaddreamin/typst.ts')
+
+    const require = createRequire(import.meta.url)
+    const wasmPath =
+      require.resolve('@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler_bg.wasm')
+    const wasmBinary = readFileSync(wasmPath)
+
+    const compiler = createTypstCompiler()
+    await compiler.init({
+      getModule: () => wasmBinary,
+      beforeBuild: [],
+    })
+
+    compiler.addSource('/main.typ', '= Hello\n\nThis is a test document.')
+
+    const { result, diagnostics } = await compiler.compile({
+      mainFilePath: '/main.typ',
+      format: 1, // CompileFormatEnum.pdf — not exported as a runtime value, see compiler.d.mts
+    })
+
+    expect(diagnostics).toBeUndefined()
+    expect(result).toBeDefined()
+    expect(result!.length).toBeGreaterThan(0)
+
+    const header = Buffer.from(result!.slice(0, 5)).toString('utf8')
+    expect(header).toBe('%PDF-')
+  }, 20_000) // WASM init is ~500-700ms; generous timeout for slower CI runners
+})


### PR DESCRIPTION
## Summary
- First slice of the #77 spike: proves Typst can compile to PDF entirely in-process via WASM — no subprocess, no native binary, no network call for the compiler itself. Landed as a committed test (`src/core/tools/typstWasmSpike.test.ts`), not a throwaway script.
- Corrects an assumption in the original issue: `@myriaddreamin/typst-ts-node-compiler` (what upstream recommends for Node) is a native N-API addon with platform-specific `.node` binaries, not WASM — not usable from a single bundled plugin `main.js`. The browser-targeted packages (`typst.ts` + `typst-ts-web-compiler`) are the right fit, since Obsidian's plugin runs inside Electron's Chromium renderer.
- Adds `obsidianmd/no-nodejs-modules: off` for test files in `eslint.config.mjs` — test files never ship in `main.js` (esbuild's entry point is `src/main.ts` only), so mobile-compatibility rules about real Node module access are noise there, same reasoning already applied to `src/test/setup.ts`'s `globalThis` usage.

Full findings and remaining open questions (font-loading mystery, real bundle-size impact, in-Obsidian load time) posted on #77. A follow-up design note on lazy-loading (deferred WASM instantiation + shipping the `.wasm` as its own file rather than inlining it into `main.js`) posted on #78.

Not wired into any production export path — this is investigation, not implementation.

## Test plan
- [x] New test passes, compiles a trivial document and verifies real PDF output (visually confirmed the rendered PDF looks correct, not just checking magic bytes)
- [x] `npm run lint` / `format:check` / `test` (320 passing) / `build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)